### PR TITLE
Updated categories.txt by adding 'background' and 'therapeutic'

### DIFF
--- a/categories.txt
+++ b/categories.txt
@@ -1,8 +1,10 @@
 arrow
+background
 cell_element
 cell_type
 compound
 human_tissue
 protein
 receptor
+therapeutic
 transporter

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,32 @@
         <plugins>
             <!-- Generate jar with dependencies -->
             <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>3.1.1</version>
+				<dependencies>
+					<!-- This dependency allows Checkstyle to understand Java 11 syntax -->
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>8.44</version>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>checkstyle-check</id>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<configLocation>checkstyle.xml</configLocation>
+					<!-- Optional: Set encoding -->
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.6</version>
                 <configuration>


### PR DESCRIPTION
The old categories.txt was missing the background and therapeutic category names. This categories.txt now matches the categories.txt in dropbox currently. The issue with the illustration-validator should now not be a problem. 